### PR TITLE
[K-BIMS-LEDET] Include GeoNode's messaging worker for async process

### DIFF
--- a/templates/k-bims-ledet/0/docker-compose.yml
+++ b/templates/k-bims-ledet/0/docker-compose.yml
@@ -47,6 +47,14 @@ services:
       smtp_user: noreply:docker
     restart: unless-stopped
 
+  cache:
+    image: memcached
+    entrypoint:
+      - memcached
+      - -m 64
+    labels:
+      io.rancher.container.pull_image: always
+
   nginx-conf-data:
     image: kartoza/ledet_nginx_conf:latest
     restart: unless-stopped
@@ -170,6 +178,129 @@ services:
       - geoserver:geoserver
       - rabbitmq:rabbitmq
       - db:db
+      - geonode-db
+    labels:
+      io.rancher.container.pull_image: always
+    restart: unless-stopped
+
+  messaging-worker:
+    image: kartoza/ledet_uwsgi:latest
+    environment:
+      DATABASE_HOST: db
+      DATABASE_NAME: gis
+      DATABASE_PASSWORD: docker
+      DATABASE_USERNAME: docker
+      DJANGO_SETTINGS_MODULE: ledet_core.settings.prod_docker
+      RABBITMQ_HOST: rabbitmq
+      VIRTUAL_HOST: ${SITE_URL}
+      VIRTUAL_PORT: '8000'
+      SITE_DOMAIN_NAME: http://${SITE_URL}
+      SITEURL: http://${SITE_URL}/
+      PYTHONPATH: /usr/src/ledet:/usr/src/app:/usr/src/bims:/home/web/django_project
+      HAYSTACK_HOST: elasticsearch
+      GEOCONTEXT_URL: ${GEOCONTEXT_URL}
+      GEOCONTEXT_COLLECTION_KEY: ${GEOCONTEXT_COLLECTION_KEY}
+      CONTACT_US_EMAIL: ${ADMIN_EMAIL}
+      ROOT_URLCONF: ledet_core.urls
+      # In this setting, we access GeoServer using Rancher Load Balancer, so
+      # it will be available from public internet
+      GEOSERVER_PUBLIC_LOCATION: http://${SITE_URL}/geoserver/
+      STATIC_ROOT: /home/web/static
+      GEONODE_DATABASE: gis
+      GEONODE_DATABASE_USER: docker
+      MEDIA_ROOT: /home/web/media
+      ADMIN_EMAILS: ${ADMIN_EMAIL}
+      GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
+      GEOIP_PATH: /home/web/media/geoip.db
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      GEONODE_INSTANCE_NAME: geonode
+      DEFAULT_BACKEND_DATASTORE: datastore
+      IS_CELERY: 'False'
+      ALLOWED_HOSTS: '["localhost","127.0.0.1","${SITE_URL}"]'
+      # In this setting, GeoNode needs to access GeoServer from internal network
+      # we use geoserver host name provided by rancher internal dns resolver
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      UWSGI_CMD: uwsgi --ini /usr/src/ledet/uwsgi.conf
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_DATABASE_PASSWORD: docker
+      C_FORCE_ROOT: 1
+      BING_MAP_KEY: ${BING_MAP_KEY}
+      IUCN_API_KEY: ${IUCN_API_KEY}
+      MAP_TILER_KEY: ${MAP_TILER_KEY}
+      SENTRY_KEY: ${SENTRY_KEY}
+    entrypoint: /bin/sh
+    command: -c "/usr/local/bin/python manage.py runmessaging -i"
+    volumes:
+      - django-static:/home/web/static:rw
+      - django-media:/home/web/media:rw
+      - django-reports:/home/web/reports
+      - django-logs:/var/log/
+    links:
+      - geoserver:geoserver
+      - rabbitmq:rabbitmq
+      - db:db
+      - geonode-db
+    labels:
+      io.rancher.container.pull_image: always
+    restart: unless-stopped
+
+  worker:
+    image: kartoza/ledet_uwsgi:latest
+    environment:
+      DATABASE_HOST: db
+      DATABASE_NAME: gis
+      DATABASE_PASSWORD: docker
+      DATABASE_USERNAME: docker
+      DJANGO_SETTINGS_MODULE: ledet_core.settings.prod_docker
+      RABBITMQ_HOST: rabbitmq
+      VIRTUAL_HOST: ${SITE_URL}
+      VIRTUAL_PORT: '8000'
+      SITE_DOMAIN_NAME: http://${SITE_URL}
+      SITEURL: http://${SITE_URL}/
+      PYTHONPATH: /usr/src/ledet:/usr/src/app:/usr/src/bims:/home/web/django_project
+      HAYSTACK_HOST: elasticsearch
+      GEOCONTEXT_URL: ${GEOCONTEXT_URL}
+      GEOCONTEXT_COLLECTION_KEY: ${GEOCONTEXT_COLLECTION_KEY}
+      CONTACT_US_EMAIL: ${ADMIN_EMAIL}
+      ROOT_URLCONF: ledet_core.urls
+      # In this setting, we access GeoServer using Rancher Load Balancer, so
+      # it will be available from public internet
+      GEOSERVER_PUBLIC_LOCATION: http://${SITE_URL}/geoserver/
+      STATIC_ROOT: /home/web/static
+      GEONODE_DATABASE: gis
+      GEONODE_DATABASE_USER: docker
+      MEDIA_ROOT: /home/web/media
+      ADMIN_EMAILS: ${ADMIN_EMAIL}
+      GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
+      GEOIP_PATH: /home/web/media/geoip.db
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      GEONODE_INSTANCE_NAME: geonode
+      DEFAULT_BACKEND_DATASTORE: datastore
+      IS_CELERY: 'False'
+      ALLOWED_HOSTS: '["localhost","127.0.0.1","${SITE_URL}"]'
+      # In this setting, GeoNode needs to access GeoServer from internal network
+      # we use geoserver host name provided by rancher internal dns resolver
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      UWSGI_CMD: uwsgi --ini /usr/src/ledet/uwsgi.conf
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_DATABASE_PASSWORD: docker
+      C_FORCE_ROOT: 1
+      BING_MAP_KEY: ${BING_MAP_KEY}
+      IUCN_API_KEY: ${IUCN_API_KEY}
+      MAP_TILER_KEY: ${MAP_TILER_KEY}
+      SENTRY_KEY: ${SENTRY_KEY}
+    entrypoint: /bin/sh
+    command: -c "celery worker --app=bims.celery:app -B  -l DEBUG -Q default,geonode,cleanup,email,update"
+    volumes:
+      - django-static:/home/web/static:rw
+      - django-media:/home/web/media:rw
+      - django-reports:/home/web/reports
+      - django-logs:/var/log/
+    links:
+      - geoserver:geoserver
+      - rabbitmq:rabbitmq
+      - db:db
+      - geonode-db
     labels:
       io.rancher.container.pull_image: always
     restart: unless-stopped
@@ -230,6 +361,7 @@ services:
       - geoserver:geoserver
       - rabbitmq:rabbitmq
       - db:db
+      - geonode-db
     labels:
       io.rancher.container.pull_image: always
       io.rancher.container.start_once: true
@@ -292,6 +424,7 @@ services:
       - geoserver:geoserver
       - rabbitmq:rabbitmq
       - db:db
+      - geonode-db
     labels:
       io.rancher.container.pull_image: always
       io.rancher.container.start_once: true
@@ -352,6 +485,7 @@ services:
       - geoserver:geoserver
       - rabbitmq:rabbitmq
       - db:db
+      - geonode-db
     labels:
       io.rancher.container.pull_image: always
       io.rancher.container.start_once: true
@@ -377,6 +511,19 @@ services:
       - postgis-data:/sql
     restart: unless-stopped
 
+  geonode-db:
+    image: kartoza/postgis:9.6-2.4
+    environment:
+      ALLOW_IP_RANGE: ${POSTGRES_HBA_RANGE}
+      POSTGRES_DB: geonode_data
+      POSTGRES_PASS: docker
+      POSTGRES_USER: docker
+    volumes:
+      - db-backups:/backups
+      - postgis-data:/sql
+      - sync-data:/raw
+    restart: unless-stopped
+
   dbbackups:
     image: kartoza/pg-backup:9.6
     hostname: pg-backups
@@ -390,6 +537,22 @@ services:
     volumes:
       - db-backups:/backups
     restart: unless-stopped
+
+  geonode-db-backups:
+    image: kartoza/pg-backup:9.6
+    environment:
+      DUMPPREFIX: PG_bimsgeonode
+      PGDATABASE: geonode_data
+      PGHOST: geonode-db
+      PGPASSWORD: docker
+      PGPORT: '5432'
+      PGUSER: docker
+    volumes:
+      - geonode-db-backups:/backups
+    links:
+      - geonode-db
+    labels:
+      io.rancher.container.pull_image: always
 
   dbrestore:
     # This container will just run, a database restore on the latest database backup


### PR DESCRIPTION
@dimasciput I'm not sure if UWSGI settings is up to date with your testing server. Please update accordingly.
The following service needs to have the same environment settings:
- uwsgi
- collectstatic
- migrate
- runmessaging-worker
- worker

and any django based service...